### PR TITLE
docs: add clickable URLs and FastAPI /docs tip

### DIFF
--- a/lab/appendix/web-development.md
+++ b/lab/appendix/web-development.md
@@ -153,9 +153,11 @@ curl http://127.0.0.1:42000/status
 
 ### Send a `GET` query using a browser
 
-1. Open a browser.
-2. Paste the URL into the address bar (e.g., `http://127.0.0.1:42000/status`).
-3. Press `Enter`.
+1. Open the link in a browser: <http://127.0.0.1:42000/status>.
+
+> [!TIP]
+> [`FastAPI`](https://fastapi.tiangolo.com/) auto-generates interactive API documentation.
+> Open <http://127.0.0.1:42000/docs> to explore all available endpoints.
 
 ### Send a `GET` query using curl
 

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -134,7 +134,9 @@ Method 2:
    to `http://127.0.0.1:42000/status`.
 2. [Pretty-print the `JSON` response](../../appendix/web-development.md#pretty-print-the-json-response).
 
-<!-- TODO add check status using the /docs -->
+> [!TIP]
+> You can also check the `/status` endpoint using the auto-generated API documentation
+> at <http://127.0.0.1:42000/docs>.
 
 ### 10. Stop the web server
 


### PR DESCRIPTION
## Summary
- Make GET query URL clickable in browser section (web-development.md)
- Add FastAPI `/docs` endpoint tip for interactive API exploration
- Replace TODO in task-1.md with actual `/docs` tip