### PR TITLE
fix(docs): replace lsof with ss and fuser for port checks

### DIFF
--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -90,11 +90,19 @@ Method 2:
 
    [Run using the `VS Code Terminal`](../../appendix/vs-code.md#run-a-command-using-the-vs-code-terminal):
 
+   `Linux` / `WSL`:
+
+   ```terminal
+   source .env.secret && ss -tlnp sport = :$PORT
+   ```
+
+   `macOS`:
+
    ```terminal
    source .env.secret && lsof -i :$PORT
    ```
 
-2. If the command produces **no output**, the port is free.
+2. If the command produces **no output** (or only a header line), the port is free.
 3. Otherwise, you need to use a [free port](#7-use-a-free-port).
 
 ### 7. Use a free port
@@ -150,6 +158,14 @@ Method 2:
 > Run if you see the `Address already in use` error after trying to run the web server.
 
 1. [Run using the `VS Code Terminal`](../../appendix/vs-code.md#run-a-command-using-the-vs-code-terminal):
+
+   `Linux` / `WSL`:
+
+   ```terminal
+   source .env.secret && fuser -k $PORT/tcp
+   ```
+
+   `macOS`:
 
    ```terminal
    source .env.secret && kill $(lsof -ti :$PORT)


### PR DESCRIPTION
## Summary
- Replace `lsof -i :$PORT` with `ss -tlnp sport = :$PORT` for checking if a port is free (step 6)
- Replace `kill $(lsof -ti :$PORT)` with `fuser -k $PORT/tcp` for force-stopping a process on a port (step 11)
- `lsof` was not installed on many student Linux machines, causing confusion in Task 1

## Why these replacements
- `ss` is part of `iproute2`, installed by default on all modern Linux distros. The appendix (`linux.md`) already documents `ss` for port inspection.
- `fuser` is part of `psmisc`, pre-installed on Debian/Ubuntu/Fedora. It's a cleaner one-liner than the `kill $(lsof ...)` pipe.

## Test plan
- [ ] Verify `ss -tlnp sport = :$PORT` shows listening processes on a known port
- [ ] Verify `fuser -k $PORT/tcp` kills a process occupying a port